### PR TITLE
Fix error: Cannot read property 'loader' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(nextConfig) {
         throw new Error('No babelConfigFile option found. Please add babelConfigFile to your next.config.js, for example: withMonorepo({ babelConfigFile: path.resolve("../babel.config.js") })')
       }
       config.module.rules.forEach((rule) => {
-        if (rule.use.loader === 'next-babel-loader') {
+        if (rule.use && rule.use.loader === 'next-babel-loader') {
           rule.use.options.configFile = nextConfig.babelConfigFile;
         }
       });


### PR DESCRIPTION
the plugin doesnt work with Next 8.1.0v because `rule.use` === undefined in some cases