### PR TITLE
Fix: Handle cases where rule.use is an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,14 @@ module.exports = function(nextConfig) {
         throw new Error('No babelConfigFile option found. Please add babelConfigFile to your next.config.js, for example: withMonorepo({ babelConfigFile: path.resolve("../babel.config.js") })')
       }
       config.module.rules.forEach((rule) => {
-        if (rule.use && rule.use.loader === 'next-babel-loader') {
-          rule.use.options.configFile = nextConfig.babelConfigFile;
-        }
+        if (rule.use) {
+          if (Array.isArray(rule.use)) {
+            const babelLoader = rule.use.find(use => typeof use === 'object' && use.loader === 'next-babel-loader');
+            babelLoader.options.configFile = nextConfig.babelConfigFile;
+          } else if (rule.use.loader === 'next-babel-loader') {
+            rule.use.options.configFile = nextConfig.babelConfigFile;
+          }
+        } 
       });
 
       if (typeof nextConfig.webpack === "function") {


### PR DESCRIPTION
With next `9.4.x` the `next-babel-loader` rule looks like 

```
{
  test: /\.(tsx|ts|js|mjs|jsx)$/,
  include: [
    '/Users/trondbergquist/code/privat/next-9.4-test/src/app',
    /next[\\/]dist[\\/]next-server[\\/]lib/,
    /next[\\/]dist[\\/]client/,
    /next[\\/]dist[\\/]pages/,
    /[\\/](strip-ansi|ansi-regex)[\\/]/
  ],
  exclude: [Function: exclude],
  use: [
    '/Users/trondbergquist/code/privat/next-9.4-test/node_modules/@next/react-refresh-utils/loader.js',
    { loader: 'next-babel-loader', options: [Object] }
  ]
}
```